### PR TITLE
Add lens to class

### DIFF
--- a/Data/Has.hs
+++ b/Data/Has.hs
@@ -67,8 +67,14 @@ may lead to type inference failure, you simply need type annotations in these ca
 
 module Data.Has (Has(..)) where
 
-import Data.Functor.Const
+import Data.Functor
 import Data.Functor.Identity
+
+#if MIN_VERSION_base(4,9,0)
+import Data.Functor.Const
+#else
+import Data.Functor.Const.Compat
+#endif
 
 type Lens t a = forall f. Functor f => (a -> f a) -> t -> f t
 

--- a/Data/Has.hs
+++ b/Data/Has.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE RankNTypes #-}
 
 {-|
 Module      : Data.Has
@@ -64,7 +65,12 @@ may lead to type inference failure, you simply need type annotations in these ca
 
 -}
 
-module Data.Has where
+module Data.Has (Has(..)) where
+
+import Data.Functor.Const
+import Data.Functor.Identity
+
+type Lens t a = forall f. Functor f => (a -> f a) -> t -> f t
 
 -- | A type class for extensible product.
 --
@@ -72,8 +78,15 @@ module Data.Has where
 -- You can define your own instance of 'Has', but most of the time tuples will do fine.
 --
 class Has a t where
+    {-# MINIMAL getter, modifier | hasL #-}
     getter :: t -> a
+    getter = getConst . hasL Const
+
     modifier :: (a -> a) -> t -> t
+    modifier f t = runIdentity (hasL (Identity . f) t)
+
+    hasL :: Lens t a
+    hasL afa t = (\a -> modifier (const a) t) <$> afa (getter t)
 
 instance Has a a where
     getter = id

--- a/data-has.cabal
+++ b/data-has.cabal
@@ -22,9 +22,14 @@ library
   -- other-modules:       
   -- other-extensions:    
   build-depends:       base < 5
+  if impl(ghc < 8)
+    build-depends:       base-compat >= 0.9
+  if impl(ghc < 7.10)
+    build-depends:       transformers
 
   -- hs-source-dirs:      
   default-language:    Haskell2010
+  extensions:          CPP
 
 benchmark bench
   type: exitcode-stdio-1.0


### PR DESCRIPTION
The motivation for this is to provide the alternative of instantiating the `Has` class with a lens, instead of defining `getter` and `modifier`. This is especially useful if you already have a lens, for example, generated by Template Haskell, then it can be used like so:

    instance Has SomeFieldType SomeData where hasL = generatedLens

Regarding the issues raised in #1:
- This can only be done by adding the lens to the class
- The lens can be used conveniently with nested data structures using `TypeApplications`, for example:

      type Config = [(String, Int)]
      configStrings :: Has Config s => s -> [String]
      configString = toListOf $ hasL @Config . traversed . hasL @String

- It doesn't complicate things for users who don't want to use lenses; it's easily ignored.

Thoughts?